### PR TITLE
Enable parsing of statnodes like <null name="min" /> <double name="mean">NaN</double>

### DIFF
--- a/SolrNet.Tests/Resources/responseWithStats.xml
+++ b/SolrNet.Tests/Resources/responseWithStats.xml
@@ -41,6 +41,16 @@
           </lst>
         </lst>
       </lst>
+      <lst name="zeroResults">
+        <null name="min"/>
+        <null name="max"/>
+        <long name="count">0</long>
+        <long name="missing">0</long>
+        <double name="sum">0.0</double>
+        <double name="sumOfSquares">0.0</double>
+        <double name="mean">NaN</double>
+        <double name="stddev">0.0</double>
+      </lst>
     </lst>
   </lst>
 </response>

--- a/SolrNet.Tests/SolrQueryResultsParserTests.cs
+++ b/SolrNet.Tests/SolrQueryResultsParserTests.cs
@@ -588,7 +588,7 @@ namespace SolrNet.Tests {
             var xml = EmbeddedResource.GetEmbeddedXml(GetType(), "Resources.responseWithStats.xml");
             var docNode = xml.XPathSelectElement("response/lst[@name='stats']");
             var stats = parser.ParseStats(docNode, "stats_fields");
-            Assert.AreEqual(1, stats.Count);
+            Assert.AreEqual(2, stats.Count);
             Assert.IsTrue(stats.ContainsKey("price"));
             var priceStats = stats["price"];
             Assert.AreEqual(0.0, priceStats.Min);
@@ -623,6 +623,16 @@ namespace SolrNet.Tests {
             Assert.AreEqual(5385249.905200001, priceInStockTrueStats.SumOfSquares);
             Assert.AreEqual(371.8072727272727, priceInStockTrueStats.Mean);
             Assert.AreEqual(621.6592938755265, priceInStockTrueStats.StdDev);
+
+            var zeroResultsStats = stats["zeroResults"];
+            Assert.AreEqual(double.NaN, zeroResultsStats.Min);
+            Assert.AreEqual(double.NaN, zeroResultsStats.Max);
+            Assert.AreEqual(0, zeroResultsStats.Count);
+            Assert.AreEqual(0, zeroResultsStats.Missing);
+            Assert.AreEqual(0.0, zeroResultsStats.Sum);
+            Assert.AreEqual(0.0, zeroResultsStats.SumOfSquares);
+            Assert.AreEqual(double.NaN, zeroResultsStats.Mean);
+            Assert.AreEqual(0.0, zeroResultsStats.StdDev);
         }
 
         [Test]

--- a/SolrNet/Impl/ResponseParsers/StatsResponseParser.cs
+++ b/SolrNet/Impl/ResponseParsers/StatsResponseParser.cs
@@ -70,22 +70,22 @@ namespace SolrNet.Impl.ResponseParsers {
                 var name = statNode.Attribute("name").Value;
                 switch (name) {
                     case "min":
-						r.Min = Convert.ToDouble( statNode.Value, CultureInfo.InvariantCulture );
+                        r.Min = GetDoubleValue(statNode);
                         break;
                     case "max":
-						r.Max = Convert.ToDouble( statNode.Value, CultureInfo.InvariantCulture );
+                        r.Max = GetDoubleValue(statNode);
                         break;
                     case "sum":
-						r.Sum = Convert.ToDouble( statNode.Value, CultureInfo.InvariantCulture );
+                        r.Sum = GetDoubleValue(statNode);
                         break;
                     case "sumOfSquares":
-						r.SumOfSquares = Convert.ToDouble( statNode.Value, CultureInfo.InvariantCulture );
+                        r.SumOfSquares = GetDoubleValue(statNode);
                         break;
                     case "mean":
-						r.Mean = Convert.ToDouble( statNode.Value, CultureInfo.InvariantCulture );
+                        r.Mean = GetDoubleValue(statNode);
                         break;
                     case "stddev":
-						r.StdDev = Convert.ToDouble( statNode.Value, CultureInfo.InvariantCulture );
+                        r.StdDev = GetDoubleValue(statNode);
                         break;
                     case "count":
 						r.Count = Convert.ToInt64( statNode.Value, CultureInfo.InvariantCulture );
@@ -99,6 +99,13 @@ namespace SolrNet.Impl.ResponseParsers {
                 }
             }
             return r;
+        }
+
+        private static double GetDoubleValue(XElement statNode) {
+            double parsedValue;
+            if (!double.TryParse(statNode.Value, NumberStyles.Float, CultureInfo.InvariantCulture, out parsedValue))
+                parsedValue = double.NaN;
+            return parsedValue;
         }
     }
 }


### PR DESCRIPTION
I have experienced errors parsing these statnodes coming from solr 5.2
`<null name="min" /> <null name="max" /> <double name="mean">NaN</double>`

`<double name="mean">NaN</double>`
is parsed to double.NaN
Empty like `<null name="min" />`
can not parse and is set to double.NaN